### PR TITLE
Add build script for packaging addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ desktop.ini
 
 # Optional: zip packages if you export addons
 *.zip
+dist/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+ADDON_NAME="BattleYells"
+DIST_DIR="dist"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+mkdir -p "$SCRIPT_DIR/$DIST_DIR"
+ZIP_PATH="$SCRIPT_DIR/$DIST_DIR/$ADDON_NAME.zip"
+
+# Remove any existing zip
+rm -f "$ZIP_PATH"
+
+cd "$PARENT_DIR"
+
+zip -r "$ZIP_PATH" "$ADDON_NAME" \
+  -x "$ADDON_NAME/$DIST_DIR/*" \
+  -x "$ADDON_NAME/.git/*" \
+  -x "$ADDON_NAME/.gitignore" \
+  -x "$ADDON_NAME/build.sh"
+
+echo "Created $ZIP_PATH"
+


### PR DESCRIPTION
## Summary
- build script `build.sh` to create a distributable ZIP in `dist`
- ignore the `dist` folder

## Testing
- `./build.sh`
- `unzip -l dist/BattleYells.zip`


------
https://chatgpt.com/codex/tasks/task_e_68449f29af448323a35c55a2023377e4